### PR TITLE
Update EEG after downsampling on import from MFF

### DIFF
--- a/io/mff_scripts_internal/mff_convert_to_EEGLAB.m
+++ b/io/mff_scripts_internal/mff_convert_to_EEGLAB.m
@@ -105,6 +105,8 @@ if FLAG_TO_STRUCT
             EEG.data(current_channel, :) = temp_data.samples;
             
         end
+        EEG.srate = EEG.srate / 2;
+        EEG.pnts = size(EEG.data, 2);
     end
     
     % delete the progress bar


### PR DESCRIPTION
I noticed that when using the downsampling option in `mff_convert_to_EEGLAB`, the sampling rate `srate` and the number of points is not updated automatically.

These additional lines should fix this. 